### PR TITLE
chore: migrate to `source_gen: ^3.0.0`, `build: ^3.0.0` and `build_test: ^3.0.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/
 codecov
 todo.md
 .lh
+.idea

--- a/lib/src/success_generator.dart
+++ b/lib/src/success_generator.dart
@@ -139,7 +139,10 @@ class SuccessGenerator {
   }
 
   /// tests the generator
-  Future<void> test() async {
+  Future<void> test({
+    TestReaderWriter? readerWriter,
+    String? rootPackage,
+  }) async {
     if (_logLevel != null) {
       Logger.root.level = _logLevel;
     }
@@ -149,6 +152,8 @@ class SuccessGenerator {
       content.input,
       outputs: compareWithFixture ? content.output : null,
       onLog: _logger ?? print,
+      rootPackage: rootPackage ?? 'a',
+      readerWriter: readerWriter,
     );
   }
 }

--- a/lib/src/success_generator.dart
+++ b/lib/src/success_generator.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: implementation_imports
-
 import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:generator_test/src/content.dart';
@@ -153,7 +151,8 @@ class SuccessGenerator {
       outputs: compareWithFixture ? content.output : null,
       onLog: _logger ?? print,
       rootPackage: rootPackage ?? 'a',
-      readerWriter: readerWriter,
+      readerWriter:
+          readerWriter ?? TestReaderWriter(rootPackage: rootPackage ?? 'a'),
     );
   }
 }

--- a/lib/src/success_generator.dart
+++ b/lib/src/success_generator.dart
@@ -149,7 +149,6 @@ class SuccessGenerator {
       content.input,
       outputs: compareWithFixture ? content.output : null,
       onLog: _logger ?? print,
-      reader: await PackageAssetReader.currentIsolate(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,16 +8,16 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  build: ^3.0.0
-  build_test: ^3.0.0
+  build: ^3.1.0
+  build_test: ^3.3.3
   logging: ^1.3.0
   meta: ^1.7.0
   path: ^1.9.0
-  source_gen: ^3.0.0
+  source_gen: ^3.1.0
 
 dev_dependencies:
   mocktail: ^1.0.4
-  test: ^1.19.2
+  test: ^1.26.3
   very_good_analysis: ^9.0.0
 
 scripts: derry.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,24 +1,24 @@
 name: generator_test
 description: A library to help test generators and build runner packages using dart files instead of Strings
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/mrgnhnt96/generator_test
 homepage: https://github.com/mrgnhnt96/generator_test
 
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
-  build: ^2.2.1
-  build_test: ^2.1.5
-  logging: ^1.0.2
+  build: ^3.0.0
+  build_test: ^3.0.0
+  logging: ^1.3.0
   meta: ^1.7.0
   path: ^1.9.0
-  source_gen: ">=1.4.0 <3.0.0"
+  source_gen: ^3.0.0
 
 dev_dependencies:
   mocktail: ^1.0.4
   test: ^1.19.2
-  very_good_analysis: ^2.4.0
+  very_good_analysis: ^9.0.0
 
 scripts: derry.yaml
 

--- a/test/src/generator_tester_test.dart
+++ b/test/src/generator_tester_test.dart
@@ -1,4 +1,5 @@
 import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
 import 'package:generator_test/src/success_generator.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:source_gen/source_gen.dart';
@@ -142,7 +143,11 @@ void main() {
 
 class FakeGeneratorTester extends Fake implements SuccessGenerator {
   @override
-  Future<void> test() => Future.value();
+  Future<void> test({
+    TestReaderWriter? readerWriter,
+    String? rootPackage,
+  }) =>
+      Future.value();
 }
 
 class MockGenerator extends Mock implements Generator {}


### PR DESCRIPTION
This pull request introduces enhancements to the `SuccessGenerator` class to allow for more flexible testing, along with dependency updates to support Dart 3 and the latest package versions. The most significant changes are the addition of optional parameters to the `test` method, improved dependency compatibility, and minor code cleanups.

**Enhancements to testing flexibility:**

* The `SuccessGenerator.test` method now accepts optional `readerWriter` and `rootPackage` parameters, allowing for customized test setups. The method also defaults `rootPackage` to `'a'` if not provided. (`lib/src/success_generator.dart` [[1]](diffhunk://#diff-76413fd7c70cd5778061988ba0ea567d2b2a14d4245b0e9406567c51a1767af6L142-R143) [[2]](diffhunk://#diff-76413fd7c70cd5778061988ba0ea567d2b2a14d4245b0e9406567c51a1767af6L152-R155)
* Updated the `FakeGeneratorTester` in tests to match the new `test` method signature. (`test/src/generator_tester_test.dart` [test/src/generator_tester_test.dartL145-R150](diffhunk://#diff-7503ddf7d6d83d3e6d59fa3f401c4f4e39c2efab7e77d59d652608ca27a67ef3L145-R150))

**Dependency and compatibility updates:**

* Updated the Dart SDK constraint to require Dart 3 and upgraded all dependencies to their latest compatible versions. (`pubspec.yaml` [pubspec.yamlL3-R21](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R21))

**Code cleanup:**

* Removed an unnecessary `ignore_for_file` comment from `success_generator.dart`. (`lib/src/success_generator.dart` [lib/src/success_generator.dartL1-L2](diffhunk://#diff-76413fd7c70cd5778061988ba0ea567d2b2a14d4245b0e9406567c51a1767af6L1-L2))
* Added a missing import for `build_test` in the test file. (`test/src/generator_tester_test.dart` [test/src/generator_tester_test.dartR2](diffhunk://#diff-7503ddf7d6d83d3e6d59fa3f401c4f4e39c2efab7e77d59d652608ca27a67ef3R2))